### PR TITLE
feat: Medical Information

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -5,7 +5,10 @@ import {NavigationContainer} from '@react-navigation/native';
 import SplashScreen from '../screens/Splash/SplashScreen';
 import LoginScreen from '../screens/Login/LoginScreen';
 import SignupScreen from '../screens/Signup/SignupScreen';
-import ChooseLanguageScreen from '../screens/ChooseLanguage/ChooseLanguageScreen'; // 언어 선택 화면 추가
+import ChooseLanguageScreen from '../screens/ChooseLanguage/ChooseLanguageScreen';
+import MedicalInformation from '../screens/MedicalInformation/MedicalInformationScreen';
+import PastMedicalHistory from '../screens/MedicalInformation/PastMedicalHistoryScreen';
+import FamilyMedicalHistory from '../screens/MedicalInformation/FamilyMedicalHistoryScreen';
 
 import BackIcon from '../img/Header/BackIcon.png';
 
@@ -61,6 +64,27 @@ const AppNavigator = () => {
           component={SignupScreen}
           options={{
             title: '회원 가입',
+          }}
+        />
+        <Stack.Screen
+          name="MedicalInformation"
+          component={MedicalInformation}
+          options={{
+            title: '건강 정보',
+          }}
+        />
+        <Stack.Screen
+          name="PastMedicalHistory"
+          component={PastMedicalHistory}
+          options={{
+            title: '과거 병력',
+          }}
+        />
+        <Stack.Screen
+          name="FamilyMedicalHistory"
+          component={FamilyMedicalHistory}
+          options={{
+            title: '가족력',
           }}
         />
       </Stack.Navigator>

--- a/src/screens/Login/LoginScreen.tsx
+++ b/src/screens/Login/LoginScreen.tsx
@@ -62,7 +62,8 @@ const LoginScreen = ({navigation}: {navigation: any}) => {
 
       {/* 링크 */}
       <View style={LoginStyles.linkContainer}>
-        <TouchableOpacity>
+        <TouchableOpacity
+          onPress={() => navigation.navigate('MedicalInformation')}>
           <Text style={LoginStyles.link}>아이디 찾기</Text>
         </TouchableOpacity>
         <Text style={LoginStyles.separator}> | </Text>

--- a/src/screens/MedicalInformation/FamilyMedicalHistoryScreen.tsx
+++ b/src/screens/MedicalInformation/FamilyMedicalHistoryScreen.tsx
@@ -1,0 +1,73 @@
+import React, {useState} from 'react';
+import {View, Text, TouchableOpacity, ScrollView} from 'react-native';
+import {useNavigation} from '@react-navigation/native';
+import styles from '../../styles/MedicalInformation/FamilyMedicalHistoryStyles';
+
+const PastMedicalHistoryScreen = () => {
+  const [selectedConditions, setSelectedConditions] = useState<string[]>([]);
+  const navigation = useNavigation();
+
+  const medicalConditions = [
+    '당뇨',
+    '고혈압',
+    '간질병증',
+    '결핵',
+    '위암',
+    '대장암',
+    '가족샘종폴립종',
+  ];
+
+  const toggleCondition = (condition: string) => {
+    if (selectedConditions.includes(condition)) {
+      setSelectedConditions(prev => prev.filter(item => item !== condition));
+    } else {
+      setSelectedConditions(prev => [...prev, condition]);
+    }
+  };
+
+  const handleNext = () => {
+    console.log('선택된 병력:', selectedConditions);
+    navigation.navigate('FamilyMedicalHistory');
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>가족력을 모두 선택해주세요</Text>
+      <ScrollView contentContainerStyle={styles.scrollContainer}>
+        {medicalConditions.map(condition => (
+          <TouchableOpacity
+            key={condition}
+            style={[
+              styles.conditionButton,
+              selectedConditions.includes(condition) &&
+                styles.conditionButtonSelected,
+            ]}
+            onPress={() => toggleCondition(condition)}>
+            <Text
+              style={[
+                styles.conditionText,
+                selectedConditions.includes(condition) &&
+                  styles.conditionTextSelected,
+              ]}>
+              {condition || ''}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+      <TouchableOpacity
+        style={[
+          styles.actionButton,
+          selectedConditions.length > 0
+            ? styles.actionButtonActive
+            : styles.actionButtonDisabled,
+        ]}
+        onPress={handleNext}>
+        <Text style={styles.actionButtonText}>
+          {selectedConditions.length > 0 ? '다음' : '건너뛰기'}
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+export default PastMedicalHistoryScreen;

--- a/src/screens/MedicalInformation/MedicalInformationScreen.tsx
+++ b/src/screens/MedicalInformation/MedicalInformationScreen.tsx
@@ -1,0 +1,63 @@
+import React, {useState} from 'react';
+import {View, Text, TextInput, TouchableOpacity} from 'react-native';
+import styles from '../../styles/MedicalInformation/MedicalInformationStyles';
+
+const MedicalInformation = ({navigation}) => {
+  const [gender, setGender] = useState('');
+  const [age, setAge] = useState('');
+  const [height, setHeight] = useState('');
+  const [weight, setWeight] = useState('');
+
+  const isFormValid = gender && age && height && weight;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>성별</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="성별 선택"
+        value={gender}
+        onChangeText={setGender}
+      />
+
+      <Text style={styles.label}>나이</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="나이 입력"
+        keyboardType="numeric"
+        value={age}
+        onChangeText={setAge}
+      />
+
+      <Text style={styles.label}>키</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="키 입력"
+        keyboardType="numeric"
+        value={height}
+        onChangeText={setHeight}
+      />
+
+      <Text style={styles.label}>몸무게</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="몸무게 입력"
+        keyboardType="numeric"
+        value={weight}
+        onChangeText={setWeight}
+      />
+
+      <TouchableOpacity
+        style={[
+          styles.button,
+          {backgroundColor: isFormValid ? '#2527BF' : '#CCCCCC'},
+        ]}
+        disabled={!isFormValid}
+        onPress={() => navigation.navigate('PastMedicalHistory')}>
+        <Text style={styles.buttonText}>다음</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+export default MedicalInformation;

--- a/src/screens/MedicalInformation/PastMedicalHistoryScreen.tsx
+++ b/src/screens/MedicalInformation/PastMedicalHistoryScreen.tsx
@@ -1,0 +1,91 @@
+import React, {useState} from 'react';
+import {View, Text, TouchableOpacity, ScrollView} from 'react-native';
+import {useNavigation} from '@react-navigation/native';
+import styles from '../../styles/MedicalInformation/PastMedicalHistoryStyles';
+
+const PastMedicalHistoryScreen = () => {
+  const [selectedConditions, setSelectedConditions] = useState<string[]>([]);
+  const navigation = useNavigation();
+
+  const medicalConditions = [
+    '당뇨',
+    '고혈압',
+    '간질병증',
+    '결핵',
+    '복부수술력',
+    '허리 척추 수술력',
+    '최근 백신 접종력',
+    '편도 절제 수술력',
+    '최근 소화기 치료 내시경 시술력',
+    '담석증',
+    '충수절제수술력',
+    '대장용종',
+    '염증성장질환',
+    '위암',
+    '대장암',
+    '만성바이러스성간염',
+    '간암',
+    '요로결석',
+    '복부절개수술력',
+    '식도수술력',
+    '역류성 식도염',
+    'B형 간염 만성 보균자',
+    '위절제술',
+    '대장절제술',
+    '담낭절제술',
+  ];
+
+  const toggleCondition = (condition: string) => {
+    if (selectedConditions.includes(condition)) {
+      setSelectedConditions(prev => prev.filter(item => item !== condition));
+    } else {
+      setSelectedConditions(prev => [...prev, condition]);
+    }
+  };
+
+  const handleNext = () => {
+    console.log('선택된 병력:', selectedConditions);
+    navigation.navigate('FamilyMedicalHistory');
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>과거 병력을 모두 선택해주세요</Text>
+      <ScrollView contentContainerStyle={styles.scrollContainer}>
+        {medicalConditions.map(condition => (
+          <TouchableOpacity
+            key={condition}
+            style={[
+              styles.conditionButton,
+              selectedConditions.includes(condition) &&
+                styles.conditionButtonSelected,
+            ]}
+            onPress={() => toggleCondition(condition)}>
+            <Text
+              style={[
+                styles.conditionText,
+                selectedConditions.includes(condition) &&
+                  styles.conditionTextSelected,
+              ]}>
+              {condition || ''}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+      <TouchableOpacity
+        style={[
+          styles.actionButton,
+          selectedConditions.length > 0
+            ? styles.actionButtonActive
+            : styles.actionButtonDisabled,
+        ]}
+        onPress={handleNext}>
+        <Text style={styles.actionButtonText}>
+          {selectedConditions.length > 0 ? '다음' : '건너뛰기'}
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+export default PastMedicalHistoryScreen;

--- a/src/styles/MedicalInformation/FamilyMedicalHistoryStyles.tsx
+++ b/src/styles/MedicalInformation/FamilyMedicalHistoryStyles.tsx
@@ -1,0 +1,61 @@
+import {StyleSheet} from 'react-native';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+    padding: 16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: '#333',
+    marginBottom: 12,
+  },
+  scrollContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'flex-start',
+  },
+  conditionButton: {
+    borderWidth: 1,
+    borderColor: '#B5B5B5',
+    borderRadius: 20,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    margin: 4,
+    backgroundColor: '#FFFFFF',
+  },
+  conditionButtonSelected: {
+    borderColor: '#2527BF',
+    backgroundColor: '#2527BF',
+  },
+  conditionText: {
+    fontSize: 16,
+    color: '#000000',
+  },
+  conditionTextSelected: {
+    color: '#FFFFFF',
+  },
+  actionButton: {
+    height: 50,
+    backgroundColor: '#d1d1d1',
+    borderRadius: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 24,
+  },
+  actionButtonActive: {
+    backgroundColor: '#2527BF',
+  },
+  actionButtonDisabled: {
+    backgroundColor: '#B5B5B5',
+  },
+  actionButtonText: {
+    fontSize: 16,
+    color: '#FFFFFF',
+    fontWeight: 'bold',
+  },
+});
+
+export default styles;

--- a/src/styles/MedicalInformation/MedicalInformationStyles.tsx
+++ b/src/styles/MedicalInformation/MedicalInformationStyles.tsx
@@ -1,0 +1,39 @@
+import {StyleSheet} from 'react-native';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: '#FFFFFF',
+  },
+  label: {
+    fontSize: 16,
+    marginBottom: 8,
+    color: '#333',
+    fontWeight: 'bold',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#CCCCCC',
+    borderRadius: 10,
+    padding: 10,
+    marginBottom: 16,
+    backgroundColor: '#F9F9F9',
+  },
+  button: {
+    height: 50,
+    backgroundColor: '#d1d1d1',
+    borderRadius: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 190,
+    width: '100%',
+  },
+  buttonText: {
+    fontSize: 16,
+    color: '#FFFFFF',
+    fontWeight: 'bold',
+  },
+});
+
+export default styles;

--- a/src/styles/MedicalInformation/PastMedicalHistoryStyles.tsx
+++ b/src/styles/MedicalInformation/PastMedicalHistoryStyles.tsx
@@ -1,0 +1,61 @@
+import {StyleSheet} from 'react-native';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+    padding: 16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: '#333',
+    marginBottom: 12,
+  },
+  scrollContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'flex-start',
+  },
+  conditionButton: {
+    borderWidth: 1,
+    borderColor: '#B5B5B5',
+    borderRadius: 20,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    margin: 4,
+    backgroundColor: '#FFFFFF',
+  },
+  conditionButtonSelected: {
+    borderColor: '#2527BF',
+    backgroundColor: '#2527BF',
+  },
+  conditionText: {
+    fontSize: 16,
+    color: '#000000',
+  },
+  conditionTextSelected: {
+    color: '#FFFFFF',
+  },
+  actionButton: {
+    height: 50,
+    backgroundColor: '#d1d1d1',
+    borderRadius: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 24,
+  },
+  actionButtonActive: {
+    backgroundColor: '#2527BF',
+  },
+  actionButtonDisabled: {
+    backgroundColor: '#B5B5B5',
+  },
+  actionButtonText: {
+    fontSize: 16,
+    color: '#FFFFFF',
+    fontWeight: 'bold',
+  },
+});
+
+export default styles;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- Medical Information

### 💡 작업동기
- 건강 정보, 과거병력, 가족력, 복용하는 약 등 개인 정보 입력받는 화면 개발

### 🔑 주요 변경사항
- LoginScreen 에서 '아이디 찾기' 누르면 MedicalInformationScreen 연결 (추후에 수정 필요) 
- 모든 Screen 에서는 항목 전부 작성했다면 '다음' 버튼 색상 활성화 
- '건너뛰기' 상태여도 다음 화면 전환 가능 

### 🏞 스크린샷
<img width="190" alt="image" src="https://github.com/user-attachments/assets/8f5866ee-5b93-43e4-96f4-7511f90b4dda" />
<img width="192" alt="image" src="https://github.com/user-attachments/assets/2fe01a46-19b0-48b1-9ffd-a4f1cc53b6fe" />
<img width="189" alt="image" src="https://github.com/user-attachments/assets/2deacc54-eebf-47fd-ba1b-c203dad619c1" />
<img width="190" alt="image" src="https://github.com/user-attachments/assets/98ebebae-198d-4f51-aec2-f4970c26b860" />
<img width="189" alt="image" src="https://github.com/user-attachments/assets/4bfbb591-6170-4390-ae17-023c431066b1" />
<img width="191" alt="image" src="https://github.com/user-attachments/assets/5192e9b6-38a5-4d50-9ffb-1a913661cff8" />
<img width="186" alt="image" src="https://github.com/user-attachments/assets/483a956a-cd90-4b87-9893-285ee32f5fd5" />
<img width="192" alt="image" src="https://github.com/user-attachments/assets/f245616f-95a2-4f44-a660-a4079e0b0a84" />


### 관련 이슈
- 건강정보 추후에 입력받는 포맷 변경 필요 (성별에서 여성/남성 선택이라거나 키나 몸무게에서 단위 표시하거나 등등)
- 백엔드 연동하여 건강정보, 과거 병력, 가족력, 복용하는 약 저장 로직 필요